### PR TITLE
#107 - Change color of links to be ADA Compliant for OIT

### DIFF
--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -87,6 +87,6 @@ export const footerData = {
     { ariaLabel: 'Github', icon: 'tabler:brand-github', href: 'https://github.com/byu-frost-lab' },
   ],
   footNote: `
-    Built using <a class="text-blue-400 underline dark:text-muted" href="https://github.com/arthelokyo"> Arthelokyo Theme</a> · All rights reserved.
+    Built using <a class="text-blue-800 underline dark:text-muted" href="https://github.com/arthelokyo"> Arthelokyo Theme</a> · All rights reserved.
   `,
 };

--- a/src/pages/get-involved.astro
+++ b/src/pages/get-involved.astro
@@ -159,7 +159,7 @@ const metadata = { title: 'Get Involved' };
           {
             title: 'Apply to BYU Graduate Programs',
             description:
-              `Once you've identified an advisor and discussed research, apply to the relevant BYU graduate program at <a href="https://gradstudies.byu.edu" target="_blank" rel="noreferrer" class="text-accent hover:underline">gradstudies.byu.edu</a>. Application deadlines are January 15 for Fall admission and August 15 for Winter admission.`,
+              `Once you've identified an advisor and discussed research, apply to the relevant BYU graduate program at <a href="https://gradstudies.byu.edu" target="_blank" rel="noreferrer" class="text-accent text-blue-800 hover:underline">gradstudies.byu.edu</a>. Application deadlines are January 15 for Fall admission and August 15 for Winter admission.`,
             icon: 'tabler:clipboard-check',
           },
         ]}
@@ -194,7 +194,7 @@ const metadata = { title: 'Get Involved' };
     <section id="questions-section" class="space-y-3 rounded-lg px-5 py-6 md:px-6 md:py-7 bg-blue-50 dark:bg-blue-900/20">
       <h2 class="text-3xl font-semibold text-accent">Questions? Let's Chat</h2>
       <p class="text-muted">
-        The best way to learn about opportunities in the FROST Lab is to reach out directly. Visit our <a href="/people" class="text-accent hover:underline">People</a> page to find contact information for faculty and graduate students, or check out our <a href="/publications" class="text-accent hover:underline">Publications</a> to see the kinds of problems we solve.
+        The best way to learn about opportunities in the FROST Lab is to reach out directly. Visit our <a href="/people" class="text-accent text-blue-800 hover:underline">People</a> page to find contact information for faculty and graduate students, or check out our <a href="/publications" class="text-accent text-blue-800 hover:underline">Publications</a> to see the kinds of problems we solve.
       </p>
       <p class="text-muted">Whether you're a freshman curious about robotics or a prospective graduate student with a specific research vision, don't hesitate to reach out!</p>
     </section>


### PR DESCRIPTION
Footer link showing which Astro template this used, as well as "gradstudies.byu.edu" "People" and "Publications" on the Get Involved page. Footer link was too light on a white background, the other three weren't a different enough blue compared to the light blue background.